### PR TITLE
Save the header if record joints twice or more times

### DIFF
--- a/Kinect2CSV/LightBuzz.Kinect2CSV/KinectCSVManager.cs
+++ b/Kinect2CSV/LightBuzz.Kinect2CSV/KinectCSVManager.cs
@@ -38,7 +38,7 @@ namespace LightBuzz.Kinect2CSV
             using (StreamWriter writer = new StreamWriter(path))
             {
                 StringBuilder line = new StringBuilder();
-                
+
                 if (!_hasEnumeratedJoints)
                 {
                     foreach (var joint in body.Joints.Values)
@@ -70,6 +70,7 @@ namespace LightBuzz.Kinect2CSV
         public void Stop()
         {
             IsRecording = false;
+            _hasEnumeratedJoints = false;
 
             Result = DateTime.Now.ToString("yyy_MM_dd_HH_mm_ss") + ".csv";
 


### PR DESCRIPTION
The last version wasn't save the header (joint name and axis) if save more that one gesture in the same session.
